### PR TITLE
Make phone numbers callable from smartphones

### DIFF
--- a/app/models/phone.rb
+++ b/app/models/phone.rb
@@ -7,6 +7,10 @@ class Phone < ApplicationRecord
 
   validates :number, presence: true, uniqueness: { case_sensitive: false }
 
+  def casted_number
+    PhoneNumber.new(number)
+  end
+
   def next
     ids = siblings.pluck(:id)
     index = ids.index(id)
@@ -27,16 +31,12 @@ class Phone < ApplicationRecord
     siblings.find(previous_index)
   end
 
-  def format_number(prefix:)
-    "#{prefix}#{number}".gsub(/[^\d]/, '')
-  end
-
   def carrier_variations
     {
-      'Oi' => format_number(prefix: '014'),
-      'TIM' => format_number(prefix: '041'),
-      'Vivo/Telefônica/GVT' => format_number(prefix: '015'),
-      'Claro/Net' => format_number(prefix: '021')
+      'Oi' => casted_number.with_prefix('014'),
+      'TIM' => casted_number.with_prefix('041'),
+      'Vivo/Telefônica/GVT' => casted_number.with_prefix('015'),
+      'Claro/Net' => casted_number.with_prefix('021')
     }
   end
 

--- a/app/models/phone_number.rb
+++ b/app/models/phone_number.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class PhoneNumber
+  def initialize(number)
+    @number = number.to_s
+  end
+
+  def to_s
+    @number
+  end
+
+  def sanitized
+    to_s.gsub(/[^\d]/, '')
+  end
+
+  def with_prefix(prefix)
+    self.class.new("#{prefix} #{self}")
+  end
+end

--- a/app/views/phones/show.html.erb
+++ b/app/views/phones/show.html.erb
@@ -13,10 +13,10 @@
   <%= link_to("Próximo >>", territory_phone_path(@territory, @phone.next), class: 'btn pull-right') %>
 </div>
 
-<h1><%= @phone.number %></h1>
+<h1><a href="tel:<%= @phone.casted_number.sanitized %>"><%= @phone.casted_number %></a></h1>
 
 <% @phone.carrier_variations.each do |carrier, number| %>
-  <p><small>Se sua operadora é</small> <%= carrier %>:<br><strong><%= number %></strong></p>
+  <p><small>Se sua operadora é</small> <%= carrier %>:<br><a href="tel:<%= number.sanitized %>"><strong><%= number %></strong></a></p>
 <% end %>
 
 <div class="btn-group btn-block">

--- a/spec/models/phone_number_spec.rb
+++ b/spec/models/phone_number_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe PhoneNumber do
+  let(:number) { described_class.new('(41) 1234-1234') }
+
+  describe '#sanitized' do
+    it 'only returns numbers' do
+      sanitized = number.with_prefix('014').sanitized
+
+      expect(sanitized).to eq('0144112341234')
+    end
+  end
+end

--- a/spec/models/phone_spec.rb
+++ b/spec/models/phone_spec.rb
@@ -43,12 +43,4 @@ RSpec.describe Phone, type: :model do
       expect(phone.number).to eq('f')
     end
   end
-
-  describe '#format_number' do
-    it 'removes any non-number char' do
-      formatted = described_class.new(number: '(41) 1234-1234').format_number(prefix: '014')
-
-      expect(formatted).to eq('0144112341234')
-    end
-  end
 end


### PR DESCRIPTION
Wrap the number with a proper anchor. Before that, only iphones could
identify the value was a number.