### PR TITLE
Fix user assignment bug

### DIFF
--- a/app/controllers/call_attempts_controller.rb
+++ b/app/controllers/call_attempts_controller.rb
@@ -31,7 +31,7 @@ class CallAttemptsController < ApplicationController
   end
 
   def update
-    if call_attempt.update(call_attempt_params)
+    if call_attempt.update(call_attempt_params.except(:user))
       return redirect_to([territory, phone])
     end
 

--- a/spec/controllers/call_attempts_controller_spec.rb
+++ b/spec/controllers/call_attempts_controller_spec.rb
@@ -92,9 +92,12 @@ RSpec.describe CallAttemptsController, type: :controller do
 
   describe 'PUT #update' do
     before do
+      call_attempt.user = regular_user
+      call_attempt.save!
       call_attempt_params[:notes] = 'updated note'
     end
 
+    let(:current_user) { admin_user }
     let(:params) do
       {
         call_attempt: call_attempt_params.merge(notes: 'updated note'),
@@ -117,6 +120,11 @@ RSpec.describe CallAttemptsController, type: :controller do
       path = territory_phone_path(territory, phone)
 
       expect(response).to redirect_to(path)
+    end
+
+    it 'does not update owner' do
+      expect { perform_request }
+        .not_to(change { call_attempt.reload.user })
     end
   end
 

--- a/spec/support/controller_spec_helper.rb
+++ b/spec/support/controller_spec_helper.rb
@@ -6,7 +6,7 @@ module ControllerSpecHelper
     base.class_eval do
       let(:regular_user) { User.new(id: 1, enabled: true, master: false) }
       let(:current_user) { regular_user }
-      let(:admin_user) { User.new(id: 1, enabled: true, master: true) }
+      let(:admin_user) { User.new(id: 2, enabled: true, master: true) }
       let(:skip_login) { false }
 
       before do


### PR DESCRIPTION
When an admin edited information of a call attempt he got assigned to
the call attempt. This commit fixes this issue.