### PR TITLE
Add phone number to vcard contact name

### DIFF
--- a/app/models/phone_vcard.rb
+++ b/app/models/phone_vcard.rb
@@ -32,7 +32,7 @@ class PhoneVcard
   end
 
   def full_name
-    "#{prefix} #{first_name}"
+    "#{prefix} #{first_name} #{@phone.casted_number.sanitized}"
   end
 
   def prefix


### PR DESCRIPTION
That makes it easier to find a particular contact that we do not know the name, only the number.