### PR TITLE
Add random phone navigation

### DIFF
--- a/.test_runner.yml
+++ b/.test_runner.yml
@@ -3,7 +3,7 @@ adapters:
   rspec_with_spring:
     adapter: custom
     file_pattern: ".*_spec.rb"
-    command: "./bin/rspec"
+    command: "time ./bin/rspec"
     commands:
       all: "{command}"
       file: "{command} {file}"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
   before_action :require_enabled_user
   helper_method :current_user
 
+  rescue_from ActiveRecord::RecordNotFound, with: :render_page404
+
   private
 
   def require_enabled_user
@@ -14,5 +16,9 @@ class ApplicationController < ActionController::Base
 
   def current_user
     @current_user ||= UserSessionService.new(session: session).current_user
+  end
+
+  def render_page404(_error)
+    render 'application/404', status: :not_found
   end
 end

--- a/app/controllers/phones_controller.rb
+++ b/app/controllers/phones_controller.rb
@@ -10,6 +10,13 @@ class PhonesController < ApplicationController
     @phone = PhoneDecorator.new(@phone_navigator.current)
   end
 
+  def random_show
+    @phone_navigator = RandomPhoneNavigator.new(current_user)
+    @territory = @phone_navigator.current.territory
+    @phone = PhoneDecorator.new(@phone_navigator.current)
+    render :show
+  end
+
   def create
     territory.create_phones(params[:phone_numbers].split("\n"))
     redirect_to action: :index

--- a/app/models/phone_action.rb
+++ b/app/models/phone_action.rb
@@ -9,6 +9,14 @@ class PhoneAction
     99 => :error
   }.freeze
 
+  CODES = {
+    call: 0,
+    return_visit: 1,
+    forget: 2,
+    verify: 3,
+    erro: 99
+  }.freeze
+
   attr_reader :code
 
   def initialize(code)

--- a/app/models/phone_navigator.rb
+++ b/app/models/phone_navigator.rb
@@ -26,6 +26,14 @@ class PhoneNavigator
     url_helper.url_for(@params.permit!.to_h.merge(id: next_id, only_path: true))
   end
 
+  def previous_label
+    I18n.t('app.links.previous')
+  end
+
+  def next_label
+    I18n.t('app.links.next')
+  end
+
   private
 
   def ids

--- a/app/models/random_phone_navigator.rb
+++ b/app/models/random_phone_navigator.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class RandomPhoneNavigator
+  def initialize(user)
+    @user = user
+  end
+
+  def current
+    @current ||= random_phone || raise(ActiveRecord::RecordNotFound)
+  end
+
+  def previous_url(url_helper)
+    url_helper.random_phone_url
+  end
+
+  def next_url(url_helper)
+    url_helper.random_phone_url
+  end
+
+  def previous_label
+    I18n.t('app.links.previous_random')
+  end
+
+  def next_label
+    I18n.t('app.links.next_random')
+  end
+
+  private
+
+  def random_phone
+    ids = Territory.unscoped.where(user: @user).select(:id)
+    query = Phone
+      .unscoped
+      .order('RANDOM()')
+      .where(territory_id: ids, action_code: PhoneAction::CODES[:call])
+      .where('last_called_at < ?', 1.day.ago)
+
+    query.first
+  end
+end

--- a/app/views/_navbar.html.erb
+++ b/app/views/_navbar.html.erb
@@ -13,6 +13,7 @@
       <li class="nav-item">
         <a class="nav-link" href="<%= territories_path %>"><%= t('app.links.territories') %></a>
       </li>
+      <li class="nav-item"><a class="nav-link" href="<%= random_phone_path  %>"><%= t('app.links.random_phone') %></a></li>
       <% if current_user.master? %>
         <li class="nav-item">
           <a class="nav-link" href="<%= users_path %>"><%= t('app.links.users') %></a>

--- a/app/views/application/404.html.erb
+++ b/app/views/application/404.html.erb
@@ -1,0 +1,3 @@
+<div class="alert alert-warning" role="alert">
+  <%= t('app.messages.page_not_found') %>
+</div>

--- a/app/views/phones/show.html.erb
+++ b/app/views/phones/show.html.erb
@@ -36,10 +36,10 @@
 
 <div class="row">
   <div class="col-6 text-left">
-    <a class="btn btn-light w-100" href="<%= @phone_navigator.previous_url(self) %>"> <%= t('app.links.previous') %></a>
+    <a class="btn btn-light w-100" href="<%= @phone_navigator.previous_url(self) %>"> <%= @phone_navigator.previous_label %></a>
   </div>
   <div class="col-6 text-right">
-    <a class="btn btn-light w-100" href="<%= @phone_navigator.next_url(self) %>"> <%= t('app.links.next') %></a>
+    <a class="btn btn-light w-100" href="<%= @phone_navigator.next_url(self) %>"> <%= @phone_navigator.next_label %></a>
   </div>
 </div>
 

--- a/config/locales/app.pt-BR.yml
+++ b/config/locales/app.pt-BR.yml
@@ -32,8 +32,10 @@ pt-BR:
       confirm_phone_delete: "Tem certeza de que deseja excluir este telefone?"
       confirm_call_attempt_delete: "Tem certeza de que deseja excluir este telefonema?"
       alert_someone_else_territory: "Cuidado! Este território está designado para outro publicador."
+      page_not_found: "Página não encontrada."
     links:
       home: "Home"
+      random_phone: "Telefone Aleatório"
       my_territories: "Meus territórios"
       territories: "Territórios"
       users: "Usuários"
@@ -46,6 +48,8 @@ pt-BR:
       edit: "Alterar"
       previous: "<< Anterior"
       next: "Próximo >>"
+      previous_random: "<< Aleatório"
+      next_random: "Aleatório >>"
       other_carrier: 'Outra operadora'
       without_area_code: 'Sem DDD'
       export_contacts: 'Importar lista de contatos'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
     get '/dev/login', to: 'development#login'
   end
 
+  get 'phones/random', to: 'phones#random_show', as: :random_phone
+
   resources :territories do
     resources :phones do
       collection do

--- a/spec/models/random_phone_navigator_spec.rb
+++ b/spec/models/random_phone_navigator_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RandomPhoneNavigator do
+  let(:factories) { TestFactories.new }
+  let(:user) { factories.users.create }
+
+  describe '#current' do
+    # rubocop:disable RSpec/ExampleLength
+    it 'returns a random user phone to call' do
+      another_user = factories.users.create
+
+      territories = []
+      territories << factories.territories.create(user: user)
+      territories << factories.territories.create(user: user)
+
+      wanted = []
+      wanted << factories.phones.create(
+        action_code: PhoneAction::CODES[:call],
+        last_called_at: 1.day.ago,
+        territory: territories[0]
+      ).id
+
+      wanted << factories.phones.create(
+        action_code: PhoneAction::CODES[:call],
+        last_called_at: 1.day.ago,
+        territory: territories[1]
+      ).id
+
+      # too recent
+      factories.phones.create(
+        action_code: PhoneAction::CODES[:call],
+        last_called_at: 1.hour.ago,
+        territory: territories[0]
+      )
+
+      # different status code
+      factories.phones.create(
+        action_code: PhoneAction::CODES[:return_visit],
+        last_called_at: 1.day.ago,
+        territory: territories[0]
+      )
+
+      # other user's
+      factories.phones.create(
+        action_code: PhoneAction::CODES[:call],
+        last_called_at: 1.day.ago,
+        territory: factories.territories.create(user: another_user)
+      ).id
+
+      collected = []
+      10.times do
+        id = described_class.new(user).current.id
+        collected << id
+        expect(id).to be_in(wanted)
+      end
+
+      expect(collected.uniq.length).not_to be(1)
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'raises error when a phone cannot be found' do
+      expect do
+        described_class.new(user).current
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
Users can now call random numbers.

Those random numbers are numbers that were not called during last 24 hours and they have the `:call` status.
